### PR TITLE
Fix for ISO90 error when compiling for Python 3.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ext_modules=[
         Extension('metamagic.json._encoder',
                   sources=['metamagic/json/_encoder/_encoder.c'],
-                  extra_compile_args=['-O3', '-std=gnu99'])
+                  extra_compile_args=['-O3', '-Wno-error=declaration-after-statement'])
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ext_modules=[
         Extension('metamagic.json._encoder',
                   sources=['metamagic/json/_encoder/_encoder.c'],
-                  extra_compile_args=['-O3'])
+                  extra_compile_args=['-O3', '-std=gnu99'])
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
I hit a common compilation issue while trying to install this module on a CentOS system with Python 3.4.1.  Adding this compilation flag fixed it.