### PR TITLE
Use collections.abc for classes that have moved

### DIFF
--- a/metamagic/json/encoder.py
+++ b/metamagic/json/encoder.py
@@ -11,7 +11,8 @@ from re import compile as re_compile
 from numbers import Number
 from decimal import Decimal
 from math import isnan, isinf
-from collections import OrderedDict, Set, Sequence, Mapping
+from collections import OrderedDict
+from collections.abc import Set, Sequence, Mapping
 from uuid import UUID
 from datetime import date, time
 

--- a/metamagic/json/tests/test_encoder.py
+++ b/metamagic/json/tests/test_encoder.py
@@ -16,7 +16,8 @@ except ImportError:
 
 from json import loads as std_loads, dumps as std_dumps
 from decimal import Decimal
-from collections import OrderedDict, Set, Sequence, Mapping
+from collections import OrderedDict
+from collections.abc import Set, Sequence, Mapping
 from uuid import UUID
 from datetime import datetime, tzinfo, timedelta, date, time
 


### PR DESCRIPTION
Python 3.9 deprecated and Python 3.10 removed importing the abstract
base classes from collections directly, switch to using the correct
location, which is collections.abc.